### PR TITLE
fixed LiftNode constructor

### DIFF
--- a/src/v5_hal/firmware/include/nodes/LiftNode.h
+++ b/src/v5_hal/firmware/include/nodes/LiftNode.h
@@ -14,17 +14,14 @@ private:
     ControllerNode* m_controller;
     MotorNode* m_left_motor;
     MotorNode* m_right_motor;
-    ADIDigitalInNode* m_bottom_limit_switch;
-    ADIDigitalInNode* m_top_limit_switch;
-    ADIAnalogInNode* m_potentiometer;
+    //ADIAnalogInNode* m_potentiometer;
 
-    PID m_lift_pid;
+    //PID m_lift_pid;
 
 public:
     LiftNode(NodeManager* node_manager, std::string handle_name, 
         ControllerNode* controller, MotorNode* left_motor, 
-        MotorNode* right_motor, ADIDigitalInNode* bottom_limit_switch, 
-        ADIDigitalInNode* top_limit_switch, ADIAnalogInNode* potentiometer);
+        MotorNode* right_motor);
     
     void initialize();
 

--- a/src/v5_hal/firmware/src/main.cpp
+++ b/src/v5_hal/firmware/src/main.cpp
@@ -96,8 +96,7 @@ void initialize() {
 
 	lift_node = new LiftNode(node_manager, "lift_node", 
         controller, left_motor_lift, 
-        right_motor_lift, bottom_limit_switch_lift, 
-		top_limit_switch_lift, potentiometer_lift
+        right_motor_lift
 	);
 
 	front_claw_piston = new ADIDigitalOutNode(node_manager, "front_claw_piston", 1, false);

--- a/src/v5_hal/firmware/src/nodes/LiftNode.cpp
+++ b/src/v5_hal/firmware/src/nodes/LiftNode.cpp
@@ -2,16 +2,11 @@
 
 LiftNode::LiftNode(NodeManager* node_manager, std::string handle_name, 
         ControllerNode* controller, MotorNode* left_motor, 
-        MotorNode* right_motor, ADIDigitalInNode* bottom_limit_switch, 
-        ADIDigitalInNode* top_limit_switch, ADIAnalogInNode* potentiometer) : 
+        MotorNode* right_motor) : 
         ILiftNode(node_manager, handle_name), 
         m_controller(controller),
         m_left_motor(left_motor),
-        m_right_motor(right_motor),
-        m_bottom_limit_switch(bottom_limit_switch),
-        m_top_limit_switch(top_limit_switch),
-        m_potentiometer(potentiometer),
-        m_lift_pid(0.03, 0., 0., 2) {
+        m_right_motor(right_motor){
 
 }
 
@@ -38,7 +33,8 @@ void LiftNode::setLiftPosition(int position) {
 };
 
 int LiftNode::getPosition() {
-    return m_potentiometer->getValue();
+    return m_left_motor->getPosition();
+    //return m_potentiometer->getValue();
 }
 
 void LiftNode::teleopPeriodic() {


### PR DESCRIPTION
The constructor for liftNode had leftover potentiometer objects that were no longer created in main, so I fixed the constructor and the rest of the files so it no longer takes in any sensors. Please make sure this builds on your computer before merging.